### PR TITLE
Ensures ktor (serialization) is excluded from minimization

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -26,6 +26,7 @@ tasks.withType<ShadowJar> {
     mergeServiceFiles()
     minimize {
         exclude(dependency("com.github.ajalt.mordant:.*:.*"))
+        exclude(dependency("io.ktor:.*:.*"))
     }
 }
 


### PR DESCRIPTION
Fixes -all jar failing at runtime due to the following serialization provider runtime lookup failure:
```
Exception in thread "main" java.util.ServiceConfigurationError: io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider: Provider io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider not found
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1219)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1228)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
	at kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:813)
	at io.ktor.serialization.kotlinx.ExtensionsJvmKt.<clinit>(ExtensionsJvm.kt:14)
	at io.ktor.serialization.kotlinx.ExtensionsKt.extensions(Extensions.kt:17)
	at io.ktor.serialization.kotlinx.KotlinxSerializationConverter.<init>(KotlinxSerializationConverter.kt:29)
	at io.ktor.serialization.kotlinx.KotlinxSerializationConverterKt.serialization(KotlinxSerializationConverter.kt:118)
	at io.ktor.serialization.kotlinx.json.JsonSupportKt.json(JsonSupport.kt:58)
	at io.ktor.serialization.kotlinx.json.JsonSupportKt.json$default(JsonSupport.kt:54)
	at com.anifichadia.figstract.HttpClientFactory.figma_KLykuaI$lambda$6$lambda$3(HttpClientFactory.kt:32)
	at io.ktor.client.HttpClientConfig.install$lambda$3(HttpClientConfig.kt:152)
	at io.ktor.client.plugins.api.ClientPluginImpl.prepare(CreatePluginUtils.kt:62)
	at io.ktor.client.plugins.api.ClientPluginImpl.prepare(CreatePluginUtils.kt:53)
	at io.ktor.client.HttpClientConfig.install$lambda$5(HttpClientConfig.kt:160)
	at io.ktor.client.HttpClientConfig.install(HttpClientConfig.kt:182)
	at io.ktor.client.HttpClient.<init>(HttpClient.kt:1374)
	at io.ktor.client.HttpClient.<init>(HttpClient.kt:1285)
	at io.ktor.client.HttpClientKt.HttpClient(HttpClient.kt:645)
	at com.anifichadia.figstract.HttpClientFactory.figma-KLykuaI(HttpClientFactory.kt:24)
	at com.anifichadia.figstract.HttpClientFactory.figma-KLykuaI$default(HttpClientFactory.kt:19)
	at com.anifichadia.figstract.cli.core.FigstractCommand.run(FigstractCommand.kt:34)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.parse(CoreSuspendingCliktCommand.kt:68)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.main(CoreSuspendingCliktCommand.kt:39)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.main(CoreSuspendingCliktCommand.kt:51)
	at com.anifichadia.figstract.cli.MainKt.main(Main.kt:12)
	at com.anifichadia.figstract.cli.MainKt$main$2.invoke(Main.kt)
	at com.anifichadia.figstract.cli.MainKt$main$2.invoke(Main.kt)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt$createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$IntrinsicsKt__IntrinsicsJvmKt$1.invokeSuspend(IntrinsicsJvm.kt:
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at kotlin.coroutines.jvm.internal.RunSuspendKt.runSuspend(RunSuspend.kt:19)
	at com.anifichadia.figstract.cli.MainKt.main(Main.kt)
```