### PR TITLE
Ensures logging can log in CLI

### DIFF
--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/FigstractCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/FigstractCommand.kt
@@ -18,7 +18,10 @@ class FigstractCommand private constructor() : SuspendingCliktCommand(
     private val auth by AuthOptionGroup()
     private val proxy by ProxyOptionGroup()
 
+    private val logLevel by logLevel()
+
     override suspend fun run() {
+        getRootLogger().level = logLevel.toLogbackLogLevel()
         val authProvider = auth.authProvider
         currentContext.findOrSetObject { authProvider }
 

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/LogLevel.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/LogLevel.kt
@@ -1,0 +1,22 @@
+package com.anifichadia.figstract.cli.core
+
+import ch.qos.logback.classic.Level
+
+enum class LogLevel {
+    OFF,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
+    ;
+}
+
+fun LogLevel.toLogbackLogLevel() = when (this) {
+    LogLevel.OFF -> Level.OFF
+    LogLevel.ERROR -> Level.ERROR
+    LogLevel.WARN -> Level.WARN
+    LogLevel.INFO -> Level.INFO
+    LogLevel.DEBUG -> Level.DEBUG
+    LogLevel.TRACE -> Level.TRACE
+}

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/LogLevelOptions.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/LogLevelOptions.kt
@@ -1,0 +1,13 @@
+package com.anifichadia.figstract.cli.core
+
+import com.github.ajalt.clikt.core.BaseCliktCommand
+import com.github.ajalt.clikt.parameters.options.OptionWithValues
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+
+fun <T : BaseCliktCommand<T>> BaseCliktCommand<T>.logLevel(): OptionWithValues<LogLevel, LogLevel, LogLevel> {
+    return option("--logLevel")
+        .enum<LogLevel>(ignoreCase = true)
+        .default(LogLevel.ERROR)
+}

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Loggers.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Loggers.kt
@@ -1,5 +1,0 @@
-package com.anifichadia.figstract.cli.core
-
-import com.anifichadia.figstract.util.createLogger
-
-val timingLogger = createLogger("Timing")

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Logging.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Logging.kt
@@ -1,0 +1,11 @@
+package com.anifichadia.figstract.cli.core
+
+import ch.qos.logback.classic.Logger
+import com.anifichadia.figstract.util.createLogger
+import org.slf4j.LoggerFactory
+
+val timingLogger = createLogger("Timing")
+
+fun getRootLogger(): Logger {
+    return LoggerFactory.getILoggerFactory().getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -27,6 +27,7 @@ tasks.withType<ShadowJar> {
     minimize {
         exclude(dependency("com.github.ajalt.mordant:.*:.*"))
         exclude(dependency("io.ktor:.*:.*"))
+        exclude(dependency("ch.qos.logback:.*:.*"))
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,12 @@ When generating credentials, ensure that the following [scopes](https://www.figm
 
 Either one auth credential can be generated with all the scopes above, or specific auth credentials can be created for each subcommand.
 
+## Logging
+
+Figstract uses [kotlin-logging](https://github.com/oshai/kotlin-logging) and [Logback](https://logback.qos.ch/) for logging, and logs errors to the console by default.
+When using the CLI, the log level can be configured using the `--logLevel` option (e.g.
+`--logLevel DEBUG`), or by configuring logback using environment variables (refer to https://logback.qos.ch/manual/configuration.html#configFileProperty).
+
 ## Assets
 
 TODO:


### PR DESCRIPTION
Ensures that logback is not minimized in the -all jar, which allows configuring logging at runtime

Allows configuring log levels using the new `--logLevel` CLI option