### PR TITLE
Ensures processing record's parent directory structure is always created

### DIFF
--- a/library-core/src/main/java/com/anifichadia/figstract/model/tracking/JsonFileProcessingRecordRepository.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/model/tracking/JsonFileProcessingRecordRepository.kt
@@ -37,7 +37,7 @@ class JsonFileProcessingRecordRepository(
             if (recordFile.exists()) {
                 recordFile.delete()
             }
-            recordFile.parentFile.mkdir()
+            recordFile.parentFile.mkdirs()
             recordFile.writeText(json.encodeToString(records))
         }
     }


### PR DESCRIPTION
Previously was using incorrect directory creation function