### PR TITLE
Fixes CLI context objects and proxy configuration not propagating to sub commands

### DIFF
--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Contexts.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/Contexts.kt
@@ -1,0 +1,41 @@
+package com.anifichadia.figstract.cli.core
+
+import com.anifichadia.figstract.apiclient.AuthProvider
+import com.anifichadia.figstract.figma.api.FigmaApi
+import com.github.ajalt.clikt.core.BaseCliktCommand
+import com.github.ajalt.clikt.core.findObject
+import com.github.ajalt.clikt.core.requireObject
+import io.ktor.client.engine.ProxyConfig
+import java.net.Proxy
+
+//region AuthProvider
+private const val KEY_AUTH_PROVIDER = "AuthProvider"
+
+fun BaseCliktCommand<*>.setAuthProvider(authProvider: AuthProvider) {
+    currentContext.findOrSetObject<AuthProvider>(KEY_AUTH_PROVIDER) { authProvider }
+}
+
+fun BaseCliktCommand<*>.getAuthProvider() = requireObject<AuthProvider>(KEY_AUTH_PROVIDER)
+//endregion
+
+//region ProxyConfig
+private const val KEY_PROXY_CONFIG = "ProxyConfig"
+
+fun BaseCliktCommand<*>.setProxy(proxyConfig: Proxy?) {
+    if (proxyConfig != null) {
+        currentContext.findOrSetObject<ProxyConfig>(KEY_PROXY_CONFIG) { proxyConfig }
+    }
+}
+
+fun BaseCliktCommand<*>.getProxy() = findObject<ProxyConfig>(KEY_PROXY_CONFIG)
+//endregion
+
+//region FigmaApi
+private const val KEY_FIGMA_API = "FigmaApi"
+
+fun BaseCliktCommand<*>.setFigmaApi(figmaApi: FigmaApi) {
+    currentContext.findOrSetObject<FigmaApi>(KEY_FIGMA_API) { figmaApi }
+}
+
+fun BaseCliktCommand<*>.getFigmaApi() = requireObject<FigmaApi>(KEY_FIGMA_API)
+//endregion

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/FigstractCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/FigstractCommand.kt
@@ -3,7 +3,6 @@ package com.anifichadia.figstract.cli.core
 import com.anifichadia.figstract.HttpClientFactory
 import com.anifichadia.figstract.cli.core.assets.AssetsCommand
 import com.anifichadia.figstract.cli.core.variables.VariablesCommand
-import com.anifichadia.figstract.figma.api.FigmaApi
 import com.anifichadia.figstract.figma.api.FigmaApiImpl
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.core.BadParameterValue
@@ -22,27 +21,26 @@ class FigstractCommand private constructor() : SuspendingCliktCommand(
 
     override suspend fun run() {
         getRootLogger().level = logLevel.toLogbackLogLevel()
+
         val authProvider = auth.authProvider
-        currentContext.findOrSetObject { authProvider }
+        setAuthProvider(authProvider)
 
         val proxyConfig = try {
             proxy.proxyConfig
         } catch (e: IllegalArgumentException) {
             throw BadParameterValue(e.message ?: "Couldn't create proxy")
         }
-        if (proxyConfig != null) {
-            currentContext.findOrSetObject { proxyConfig }
-        }
+        setProxy(proxyConfig)
 
         val figmaHttpClient = HttpClientFactory.figma(
             proxy = proxyConfig,
         )
-        currentContext.findOrSetObject<FigmaApi> {
+        setFigmaApi(
             FigmaApiImpl(
                 httpClient = figmaHttpClient,
                 authProvider = authProvider,
             )
-        }
+        )
     }
 
     companion object {

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
@@ -3,8 +3,9 @@ package com.anifichadia.figstract.cli.core.assets
 import com.anifichadia.figstract.HttpClientFactory
 import com.anifichadia.figstract.cli.core.ProcessingRecordOptionGroup
 import com.anifichadia.figstract.cli.core.defaultPropertyValueSource
+import com.anifichadia.figstract.cli.core.getFigmaApi
+import com.anifichadia.figstract.cli.core.getProxy
 import com.anifichadia.figstract.cli.core.outDirectory
-import com.anifichadia.figstract.figma.api.FigmaApi
 import com.anifichadia.figstract.importer.asset.FigmaAssetImporter
 import com.anifichadia.figstract.importer.asset.model.AssetFileHandler
 import com.anifichadia.figstract.model.tracking.JsonFileProcessingRecordRepository
@@ -13,10 +14,7 @@ import com.anifichadia.figstract.type.fold
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.context
-import com.github.ajalt.clikt.core.findObject
-import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
-import io.ktor.client.engine.ProxyConfig
 import kotlinx.coroutines.coroutineScope
 import java.io.File
 
@@ -31,8 +29,8 @@ abstract class AssetsCommand : SuspendingCliktCommand(
         }
     }
 
-    private val proxyConfig by findObject<ProxyConfig>()
-    private val figmaApi by requireObject<FigmaApi>()
+    private val proxyConfig by getProxy()
+    private val figmaApi by getFigmaApi()
 
     private val processingRecordOptions by ProcessingRecordOptionGroup()
 

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/variables/VariablesCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/variables/VariablesCommand.kt
@@ -1,14 +1,13 @@
 package com.anifichadia.figstract.cli.core.variables
 
 import com.anifichadia.figstract.cli.core.defaultPropertyValueSource
+import com.anifichadia.figstract.cli.core.getFigmaApi
 import com.anifichadia.figstract.cli.core.outDirectory
-import com.anifichadia.figstract.figma.api.FigmaApi
 import com.anifichadia.figstract.importer.variable.FigmaVariableImporter
 import com.anifichadia.figstract.importer.variable.model.VariableFileHandler
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.context
-import com.github.ajalt.clikt.core.requireObject
 import kotlinx.coroutines.coroutineScope
 import java.io.File
 
@@ -23,7 +22,7 @@ abstract class VariablesCommand : SuspendingCliktCommand(
         }
     }
 
-    private val figmaApi by requireObject<FigmaApi>()
+    private val figmaApi by getFigmaApi()
 
     private val outDirectory by outDirectory()
 


### PR DESCRIPTION
Setting an object with the context requires a unique key. It's not derived based on the object type, but the key used