### PR TITLE
Updates shadowjar generation to not exclude image processing libs for cli all jar

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,6 +28,7 @@ tasks.withType<ShadowJar> {
         exclude(dependency("com.github.ajalt.mordant:.*:.*"))
         exclude(dependency("io.ktor:.*:.*"))
         exclude(dependency("ch.qos.logback:.*:.*"))
+        exclude(dependency("com.sksamuel.scrimage:.*:.*"))
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.anifichadia.figstract
-VERSION=0.4.1
+VERSION=0.4.2
 kotlin.code.style=official
 org.gradle.configuration-cache=true
 org.gradle.caching=true


### PR DESCRIPTION
The CLI all jar was producing class not found exceptions at runtime related to scrimage