### PR TITLE
Updates fatjar configuration issue affecting webp handling

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -25,6 +25,7 @@ application {
 
 tasks.withType<ShadowJar> {
     mergeServiceFiles()
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     minimize {
         exclude(dependency("com.github.ajalt.mordant:.*:.*"))
         exclude(dependency("io.ktor:.*:.*"))


### PR DESCRIPTION
[Shadow 9.0.1](https://github.com/GradleUp/shadow/releases/tag/9.0.1) changed the `duplicateStrategy` to exclude, which causes scrimage-webp native binaries to not load correctly when using the fatjar / all jar.

This would result in the following error when converting to webp:
```
com.sksamuel.scrimage.webp.WebpImageReader@5c3dbaa4 failed due to java.io.IOException: [Decoding of [path\to\file] failed., Status: 3(BITSTREAM_ERROR)]
                at com.sksamuel.scrimage.nio.ImageReaders.read(ImageReaders.java:66)
                at com.sksamuel.scrimage.nio.ImageReaders.read(ImageReaders.java:37)
                at com.sksamuel.scrimage.nio.ImmutableImageLoader.load(ImmutableImageLoader.java:240)
                at com.sksamuel.scrimage.nio.ImmutableImageLoader.fromBytes(ImmutableImageLoader.java:104)
                at com.anifichadia.figstract.importer.asset.model.importing.ImportPipelineStepsKt$transform$1.process(ImportPipelineSteps.kt:59)
                at com.anifichadia.figstract.importer.asset.model.importing.ImportPipeline$Step$DescribeableStep.process(ImportPipeline.kt)
                at com.anifichadia.figstract.importer.asset.model.importing.ImportPipeline$Step$Then.process(ImportPipeline.kt:124)
                ... 11 common frames omitted
```

https://github.com/AniFichadia/Figstract/tree/0.4.2 used Shadow `9.0.0-beta8`, which was working. It took a bit of a version downgrading binary search to find the changelog that mentioned the config change in Shadow.