### PR TITLE
Adds failure handling and logging for Assets

### DIFF
--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
@@ -9,6 +9,7 @@ import com.anifichadia.figstract.cli.core.getProxy
 import com.anifichadia.figstract.cli.core.outDirectory
 import com.anifichadia.figstract.importer.asset.FigmaAssetImporter
 import com.anifichadia.figstract.importer.asset.model.AssetFileHandler
+import com.anifichadia.figstract.importer.asset.reporting.JsonFileImportReportRepository
 import com.anifichadia.figstract.model.tracking.JsonFileProcessingRecordRepository
 import com.anifichadia.figstract.model.tracking.NoOpProcessingRecordRepository
 import com.anifichadia.figstract.type.fold
@@ -62,10 +63,15 @@ abstract class AssetsCommand : SuspendingCliktCommand(
             NoOpProcessingRecordRepository
         }
 
+        val importReportRepository = JsonFileImportReportRepository(
+            outputDir = outDirectory,
+        )
+
         val importer = FigmaAssetImporter(
             figmaApi = figmaApi,
             downloaderHttpClient = downloaderHttpClient,
             processingRecordRepository = processingRecordRepository,
+            importReportRepository = importReportRepository,
         )
         coroutineScope {
             importer.importFromFigma(

--- a/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
+++ b/cli-core/src/main/java/com/anifichadia/figstract/cli/core/assets/AssetsCommand.kt
@@ -15,6 +15,7 @@ import com.anifichadia.figstract.model.tracking.NoOpProcessingRecordRepository
 import com.anifichadia.figstract.type.fold
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
 import kotlinx.coroutines.coroutineScope
@@ -74,9 +75,14 @@ abstract class AssetsCommand : SuspendingCliktCommand(
             importReportRepository = importReportRepository,
         )
         coroutineScope {
-            importer.importFromFigma(
-                handlers = createHandlers(outDirectory),
-            )
+            try {
+                importer.importFromFigma(
+                    handlers = createHandlers(outDirectory),
+                )
+            } catch (e: Throwable) {
+                echo(e.message, err = true)
+                throw ProgramResult(1)
+            }
         }
     }
 }

--- a/library-core/src/main/java/com/anifichadia/figstract/figma/api/FigmaApiProxyWithFlowControl.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/figma/api/FigmaApiProxyWithFlowControl.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import kotlin.math.pow
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -28,7 +30,8 @@ class FigmaApiProxyWithFlowControl(
     private val wrapped: FigmaApi,
     concurrencyLimit: Int = DEFAULT_CONCURRENCY_LIMIT,
     private val retryLimit: Int = DEFAULT_RETRY_LIMIT,
-    private val throttleDelayDurations: List<Duration> = DEFAULT_THROTTLE_DELAY_DURATIONS,
+    private val baseDelay: Duration = DEFAULT_BASE_DELAY,
+    private val maxDelay: Duration = DEFAULT_MAX_DELAY,
 ) : FigmaApi {
     private val concurrencySemaphore = Semaphore(concurrencyLimit)
     private val floodMitigationMutex = Mutex()
@@ -122,7 +125,7 @@ class FigmaApiProxyWithFlowControl(
                     return lastApiResponse
                 } else if (!floodMitigationMutex.isLocked) {
                     floodMitigationMutex.withLock {
-                        delay(throttleDelayDurations[(attempt - 1).coerceIn(throttleDelayDurations.indices)])
+                        delay(throttleDelay(attempt))
                     }
                 }
 
@@ -133,16 +136,15 @@ class FigmaApiProxyWithFlowControl(
         }
     }
 
+    private fun throttleDelay(attempt: Int): Duration {
+        val exponential = minOf(maxDelay, baseDelay * 2.0.pow(attempt))
+        return exponential * Random.nextDouble(0.5, 1.0)
+    }
+
     companion object {
         const val DEFAULT_CONCURRENCY_LIMIT = 5
-        const val DEFAULT_RETRY_LIMIT = 5
-
-        val DEFAULT_THROTTLE_DELAY_DURATIONS: List<Duration> = listOf(
-            1.seconds,
-            5.seconds,
-            15.seconds,
-            30.seconds,
-            1.minutes,
-        )
+        const val DEFAULT_RETRY_LIMIT = 10
+        val DEFAULT_BASE_DELAY = 1.seconds
+        val DEFAULT_MAX_DELAY = 1.minutes
     }
 }

--- a/library-core/src/main/java/com/anifichadia/figstract/figma/api/FigmaApiProxyWithFlowControl.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/figma/api/FigmaApiProxyWithFlowControl.kt
@@ -52,14 +52,47 @@ class FigmaApiProxyWithFlowControl(
         scale: Float?,
         contentsOnly: Boolean?,
         useAbsoluteBounds: Boolean?,
-    ): ApiResponse<GetImageResponse> = wrapRequest {
-        getImages(
-            key = key,
-            ids = ids,
-            format = format,
-            scale = scale,
-            contentsOnly = contentsOnly,
-            useAbsoluteBounds = useAbsoluteBounds,
+    ): ApiResponse<GetImageResponse> {
+        val response = wrapRequest {
+            getImages(
+                key = key,
+                ids = ids,
+                format = format,
+                scale = scale,
+                contentsOnly = contentsOnly,
+                useAbsoluteBounds = useAbsoluteBounds,
+            )
+        }
+
+        if (!response.errorMatches(GetImageResponse.tooManyImages) || ids.size <= 1) return response
+
+        // Batch too large and rejected by figma, retry each image individually and merge the results
+        val mergedImages = mutableMapOf<String, String?>()
+        var lastSuccess: ApiResponse.Success<GetImageResponse>? = null
+        for (id in ids) {
+            val singleResponse = wrapRequest {
+                getImages(
+                    key = key,
+                    ids = listOf(id),
+                    format = format,
+                    scale = scale,
+                    contentsOnly = contentsOnly,
+                    useAbsoluteBounds = useAbsoluteBounds,
+                )
+            }
+
+            if (singleResponse.isSuccess()) {
+                lastSuccess = singleResponse as ApiResponse.Success<GetImageResponse>
+                mergedImages.putAll(singleResponse.body.images)
+            } else {
+                return singleResponse
+            }
+        }
+
+        return lastSuccess?.copy(
+            body = GetImageResponse(images = mergedImages),
+        ) ?: ApiResponse.Failure.RequestError(
+            exception = IllegalStateException("No successful responses when retrying images individually for key: $key"),
         )
     }
 

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
@@ -6,8 +6,11 @@ import com.anifichadia.figstract.figma.api.KnownErrors.errorMatches
 import com.anifichadia.figstract.figma.model.GetFilesResponse
 import com.anifichadia.figstract.figma.model.GetImageResponse
 import com.anifichadia.figstract.importer.asset.model.AssetFileHandler
+import com.anifichadia.figstract.importer.asset.model.ImportResult
 import com.anifichadia.figstract.importer.asset.model.Instruction
 import com.anifichadia.figstract.importer.asset.model.exporting.ExportConfig
+import com.anifichadia.figstract.importer.asset.reporting.FigmaImportReport
+import com.anifichadia.figstract.importer.asset.reporting.ImportReportRepository
 import com.anifichadia.figstract.importer.getFileWithBranchName
 import com.anifichadia.figstract.model.tracking.ProcessingRecordRepository
 import com.anifichadia.figstract.util.createLogger
@@ -44,24 +47,41 @@ class FigmaAssetImporter(
     private val figmaApi: FigmaApi,
     private val downloaderHttpClient: HttpClient,
     private val processingRecordRepository: ProcessingRecordRepository,
+    private val importReportRepository: ImportReportRepository,
     private val defaultContext: CoroutineContext = Dispatchers.Default,
     private val networkContext: CoroutineContext = Dispatchers.IO,
     private val importPipelineContext: CoroutineContext = Dispatchers.IO,
 ) {
     suspend fun importFromFigma(handlers: List<AssetFileHandler>) {
+        val reports = handlers.associate { handler ->
+            handler.figmaFile to FigmaImportReport(handler.figmaFile)
+        }
+
         val importFlow = handlers
-            .map { handler -> createProcessingFlowForHandler(handler) }
+            .map { handler -> createProcessingFlowForHandler(handler, reports.getValue(handler.figmaFile)) }
             .merge()
 
         coroutineScope {
             importFlow.launchIn(this)
         }
+
+        for (report in reports.values) {
+            importReportRepository.save(report)
+            logger.info { report.summary() }
+
+            if (report.hasFailures()) {
+                logger.error { "Import failures for ${report.figmaFile}: ${report.failures().size} failure(s)" }
+            }
+        }
     }
 
-    private fun createProcessingFlowForHandler(handler: AssetFileHandler): Flow<Unit> {
+    private fun createProcessingFlowForHandler(
+        handler: AssetFileHandler,
+        report: FigmaImportReport,
+    ): Flow<Unit> {
         return flow {
             val resolvedHandler = assetFileHandlerForBranch(handler)
-            val flow = createResolvedProcessingFlow(resolvedHandler)
+            val flow = createResolvedProcessingFlow(resolvedHandler, report)
             emitAll(flow)
         }
     }
@@ -78,7 +98,10 @@ class FigmaAssetImporter(
         return handler.withResolvedBranchKey(branchKey)
     }
 
-    private fun createResolvedProcessingFlow(handler: AssetFileHandler): Flow<Unit> {
+    private fun createResolvedProcessingFlow(
+        handler: AssetFileHandler,
+        report: FigmaImportReport,
+    ): Flow<Unit> {
         val figmaFile = handler.figmaFile
         var lastUpdated: OffsetDateTime? = null
 
@@ -96,11 +119,11 @@ class FigmaAssetImporter(
             }
             .onCompletion { handler.lifecycle.onFileRetrievalFinished() }
 
-        val exportFlow = createExportFlow(fileFlow)
+        val exportFlow = createExportFlow(fileFlow, report)
             .onStart { handler.lifecycle.onExportStarted() }
             .onCompletion { handler.lifecycle.onExportFinished() }
 
-        val importFlow = createImportFlow(exportFlow)
+        val importFlow = createImportFlow(exportFlow, report)
             .onStart { handler.lifecycle.onImportStarted() }
             .onCompletion {
                 handler.lifecycle.onImportFinished()
@@ -136,7 +159,10 @@ class FigmaAssetImporter(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun createExportFlow(fileFlow: Flow<Pair<AssetFileHandler, ApiResponse<GetFilesResponse>>>): Flow<ExportOutput> {
+    private fun createExportFlow(
+        fileFlow: Flow<Pair<AssetFileHandler, ApiResponse<GetFilesResponse>>>,
+        report: FigmaImportReport,
+    ): Flow<ExportOutput> {
         val instructionsFlow = fileFlow
             .filter { (handler, getFileApiResponse) ->
                 val response = getFileApiResponse.successBodyOrThrow()
@@ -169,7 +195,8 @@ class FigmaAssetImporter(
             .flatMapConcat { (handler, exportsByConfig) ->
                 val assetsPerChunk = handler.assetsPerChunk
 
-                exportsByConfig.entries
+                exportsByConfig
+                    .entries
                     .map { (exportConfig, exportInstructions) ->
                         val exportDataSize = exportInstructions.size
                         val chunkCount = ceil(exportDataSize.toDouble() / assetsPerChunk).toInt()
@@ -274,15 +301,20 @@ class FigmaAssetImporter(
 
                         body.images.entries.asFlow()
                             .mapNotNull { (nodeId, imageUrl) ->
-                                if (imageUrl == null) {
-                                    // TODO: error handling
-                                    logger.error { "Fetching image for $nodeId failed due to null image URL" }
+                                val instructionsForNode = instructions.filter { it.export.nodeId == nodeId }
 
+                                if (imageUrl == null) {
+                                    logger.error { "Fetching image for $nodeId failed due to null image URL" }
+                                    instructionsForNode.forEach { _ ->
+                                        report.record(
+                                            ImportResult.Failure.NoImageUrl(
+                                                figmaFile = handler.figmaFile,
+                                                nodeId = nodeId,
+                                            )
+                                        )
+                                    }
                                     return@mapNotNull null
                                 }
-
-                                val instructionsForNode =
-                                    instructions.filter { it.export.nodeId == nodeId }
 
                                 try {
                                     val imageResponse = downloaderHttpClient.get(
@@ -290,10 +322,26 @@ class FigmaAssetImporter(
                                     )
                                     val bodyBytes = imageResponse.bodyAsChannel().toByteArray()
 
-                                    instructionsForNode.map { instruction -> instruction to bodyBytes }
+                                    instructionsForNode.map { instruction ->
+                                        ExportOutput(
+                                            handler = handler,
+                                            instruction = instruction,
+                                            data = bodyBytes,
+                                            imageUrl = imageUrl,
+                                        )
+                                    }
                                 } catch (e: Throwable) {
                                     logger.error(e) { "Failed fetching image for $nodeId at $imageUrl" }
-                                    // TODO: error handling
+                                    instructionsForNode.forEach { instruction ->
+                                        report.record(
+                                            ImportResult.Failure.DownloadFailed(
+                                                figmaFile = handler.figmaFile,
+                                                nodeId = nodeId,
+                                                imageUrl = imageUrl,
+                                                cause = e,
+                                            )
+                                        )
+                                    }
                                     null
                                 }
                             }
@@ -301,29 +349,41 @@ class FigmaAssetImporter(
                             .flowOn(networkContext)
                     }
                     .flattenConcat()
-                    .map { (instruction, data) ->
-                        ExportOutput(
-                            handler = handler,
-                            instruction = instruction,
-                            data = data,
-                        )
-                    }
                     .flowOn(defaultContext)
             }
 
         return exportFlow
     }
 
-    private fun createImportFlow(exportFlow: Flow<ExportOutput>): Flow<Unit> {
+    private fun createImportFlow(
+        exportFlow: Flow<ExportOutput>,
+        report: FigmaImportReport,
+    ): Flow<Unit> {
         return exportFlow
-            .map { (handler, instruction, data) ->
+            .map { exportOutput ->
+                val (handler, instruction, data, imageUrl) = exportOutput
                 logger.debug { "Importing ${handler.figmaFile} $instruction: Started" }
                 try {
                     instruction.import.pipeline.execute(instruction, data)
+                    report.record(
+                        ImportResult.Success(
+                            figmaFile = handler.figmaFile,
+                            nodeId = instruction.export.nodeId,
+                            imageUrl = imageUrl,
+                            instruction = instruction,
+                        )
+                    )
                     logger.info { "Importing ${handler.figmaFile} $instruction: Finished true" }
                 } catch (e: Throwable) {
                     logger.error(e) { "Importing ${handler.figmaFile} $instruction: Finished false" }
-                    // TODO: error handling
+                    report.record(
+                        ImportResult.Failure.ImportPipelineFailed(
+                            figmaFile = handler.figmaFile,
+                            nodeId = instruction.export.nodeId,
+                            instruction = instruction,
+                            cause = e,
+                        )
+                    )
                 }
             }
             .flowOn(importPipelineContext)
@@ -347,6 +407,7 @@ class FigmaAssetImporter(
         val handler: AssetFileHandler,
         val instruction: Instruction,
         val data: ByteArray,
+        val imageUrl: String,
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
@@ -104,7 +104,7 @@ class FigmaAssetImporter(
 
         val handlersFlow = flowOf(handler)
 
-        val fileFlow = createFigmaFileFlow(handlersFlow)
+        val fileFlow = createFigmaFileFlow(handlersFlow, report)
             .onStart {
                 handler.lifecycle.onStarted()
                 handler.lifecycle.onFileRetrievalStarted()
@@ -135,7 +135,10 @@ class FigmaAssetImporter(
         return importFlow
     }
 
-    private fun createFigmaFileFlow(handlers: Flow<AssetFileHandler>): Flow<Pair<AssetFileHandler, ApiResponse<GetFilesResponse>>> {
+    private fun createFigmaFileFlow(
+        handlers: Flow<AssetFileHandler>,
+        report: FigmaImportReport,
+    ): Flow<Pair<AssetFileHandler, ApiResponse<GetFilesResponse>>> {
         return handlers
             .flowOn(defaultContext)
             .map { handler ->
@@ -147,10 +150,18 @@ class FigmaAssetImporter(
                 logger.info { "Fetching ${handler.figmaFile}: Finish ${getFileApiResponse.isSuccess()}" }
                 getFileApiResponse.logError { "Fetching ${handler.figmaFile}" }
 
+                if (!getFileApiResponse.isSuccess()) {
+                    report.record(
+                        ImportResult.Failure.GetFileFailed(
+                            figmaFile = handler.figmaFile,
+                            cause = (getFileApiResponse as ApiResponse.Failure).asException(),
+                        )
+                    )
+                }
+
                 handler to getFileApiResponse
             }
             .flowOn(networkContext)
-            // TODO: error handling
             .filter { (_, apiResponse) -> apiResponse.isSuccess() }
             .flowOn(defaultContext)
     }
@@ -246,7 +257,7 @@ class FigmaAssetImporter(
                         val cause = (getImagesApiResponse as ApiResponse.Failure).asException()
                         instructions.forEach { instruction ->
                             report.record(
-                                ImportResult.Failure.GetImagesFailed(
+                                ImportResult.Failure.NodeFailure.GetImagesFailed(
                                     figmaFile = handler.figmaFile,
                                     nodeId = instruction.export.nodeId,
                                     cause = cause,
@@ -265,7 +276,7 @@ class FigmaAssetImporter(
                                 logger.error { "Fetching image for $nodeId failed due to null image URL" }
                                 instructionsForNode.forEach { _ ->
                                     report.record(
-                                        ImportResult.Failure.NoImageUrl(
+                                        ImportResult.Failure.NodeFailure.NoImageUrl(
                                             figmaFile = handler.figmaFile,
                                             nodeId = nodeId,
                                         )
@@ -275,10 +286,10 @@ class FigmaAssetImporter(
                             }
 
                             try {
-                                    val imageResponse = downloaderHttpClient.get(
-                                        urlString = imageUrl,
-                                    )
-                                    val bodyBytes = imageResponse.bodyAsChannel().toByteArray()
+                                val imageResponse = downloaderHttpClient.get(
+                                    urlString = imageUrl,
+                                )
+                                val bodyBytes = imageResponse.bodyAsChannel().toByteArray()
 
                                 instructionsForNode.map { instruction ->
                                     ExportOutput(
@@ -290,16 +301,16 @@ class FigmaAssetImporter(
                                 }
                             } catch (e: Throwable) {
                                 logger.error(e) { "Failed fetching image for $nodeId at $imageUrl" }
-                                    instructionsForNode.forEach { instruction ->
-                                        report.record(
-                                            ImportResult.Failure.DownloadFailed(
-                                                figmaFile = handler.figmaFile,
-                                                nodeId = nodeId,
-                                                imageUrl = imageUrl,
-                                                cause = e,
-                                            )
+                                instructionsForNode.forEach { _ ->
+                                    report.record(
+                                        ImportResult.Failure.NodeFailure.DownloadFailed(
+                                            figmaFile = handler.figmaFile,
+                                            nodeId = nodeId,
+                                            imageUrl = imageUrl,
+                                            cause = e,
                                         )
-                                    }
+                                    )
+                                }
                                 null
                             }
                         }
@@ -334,7 +345,7 @@ class FigmaAssetImporter(
                 } catch (e: Throwable) {
                     logger.error(e) { "Importing ${handler.figmaFile} $instruction: Finished false" }
                     report.record(
-                        ImportResult.Failure.ImportPipelineFailed(
+                        ImportResult.Failure.NodeFailure.ImportPipelineFailed(
                             figmaFile = handler.figmaFile,
                             nodeId = instruction.export.nodeId,
                             instruction = instruction,

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
@@ -2,9 +2,7 @@ package com.anifichadia.figstract.importer.asset
 
 import com.anifichadia.figstract.apiclient.ApiResponse
 import com.anifichadia.figstract.figma.api.FigmaApi
-import com.anifichadia.figstract.figma.api.KnownErrors.errorMatches
 import com.anifichadia.figstract.figma.model.GetFilesResponse
-import com.anifichadia.figstract.figma.model.GetImageResponse
 import com.anifichadia.figstract.importer.asset.model.AssetFileHandler
 import com.anifichadia.figstract.importer.asset.model.ImportResult
 import com.anifichadia.figstract.importer.asset.model.Instruction
@@ -27,7 +25,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapMerge
-import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -231,10 +228,9 @@ class FigmaAssetImporter(
                 val exportConfig = chunk.exportConfig
                 val chunkIndex = chunk.chunkIndex
                 val instructions = chunk.instructions
-                val isRetry = chunk.isRetry
 
-                val firstAttemptFlow = flow {
-                    logger.debug { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: ${isRetry}, $exportConfig: Started" }
+                flow {
+                    logger.debug { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, $exportConfig: Started" }
 
                     val getImagesApiResponse = figmaApi.getImages(
                         key = handler.figmaFile,
@@ -243,95 +239,46 @@ class FigmaAssetImporter(
                         scale = exportConfig.scale,
                         contentsOnly = exportConfig.contentsOnly,
                     )
-                    getImagesApiResponse.logError { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: ${isRetry}, $exportConfig" }
+                    getImagesApiResponse.logError { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, $exportConfig" }
+                    logger.info { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, $exportConfig: Finish ${getImagesApiResponse.isSuccess()}" }
 
-                    emit(
-                        GetImagesResult(
-                            originalChunk = chunk,
-                            expectedInstructions = instructions,
-                            getImageResponse = getImagesApiResponse,
-                        )
-                    )
-
-                    logger.info { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: ${isRetry}, $exportConfig: Finish ${getImagesApiResponse.isSuccess()}" }
-                }
-                    .flowOn(networkContext)
-
-                val retryFlow = firstAttemptFlow
-                    .filter { it.getImageResponse.errorMatches(GetImageResponse.tooManyImages) && it.expectedInstructions.size > 1 }
-                    .flatMapMerge { it.expectedInstructions.asFlow() }
-                    .map { instruction ->
-                        val instructions = listOf(instruction)
-
-                        logger.debug { "Getting images as retry ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: true, $exportConfig: Started" }
-                        val getImagesApiResponse = figmaApi.getImages(
-                            key = handler.figmaFile,
-                            ids = instructions.map { it.export.nodeId },
-                            format = exportConfig.format,
-                            scale = exportConfig.scale,
-                            contentsOnly = exportConfig.contentsOnly,
-                        )
-                        getImagesApiResponse.logError { "Getting images as retry ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: true, $exportConfig" }
-                        logger.info { "Getting images as retry ${handler.figmaFile}, chunkIndex: $chunkIndex, isRetry: true, $exportConfig: Finish ${getImagesApiResponse.isSuccess()}" }
-
-                        GetImagesResult(
-                            originalChunk = chunk.copy(
-                                instructions = instructions,
-                                isRetry = true,
-                            ),
-                            expectedInstructions = instructions,
-                            getImageResponse = getImagesApiResponse,
-                        )
-                    }
-                    .flowOn(networkContext)
-
-                merge(
-                    firstAttemptFlow.filter { it.getImageResponse.isSuccess() },
-                    retryFlow,
-                )
                     // TODO: error handling
-                    .filter { result -> result.getImageResponse.isSuccess() }
-                    .map { result ->
-                        val body = result.getImageResponse.successBodyOrThrow()
-                        val instructions = result.expectedInstructions
+                    if (!getImagesApiResponse.isSuccess()) return@flow
 
-                        if (body.images.keys != instructions.map { it.export.nodeId }.toSet()) {
-                            error("Not all images retrieved")
-                        }
+                    val body = getImagesApiResponse.successBodyOrThrow()
+                    body.images.entries.asFlow()
+                        .mapNotNull { (nodeId, imageUrl) ->
+                            val instructionsForNode = instructions.filter { it.export.nodeId == nodeId }
 
-                        body.images.entries.asFlow()
-                            .mapNotNull { (nodeId, imageUrl) ->
-                                val instructionsForNode = instructions.filter { it.export.nodeId == nodeId }
-
-                                if (imageUrl == null) {
-                                    logger.error { "Fetching image for $nodeId failed due to null image URL" }
-                                    instructionsForNode.forEach { _ ->
-                                        report.record(
-                                            ImportResult.Failure.NoImageUrl(
-                                                figmaFile = handler.figmaFile,
-                                                nodeId = nodeId,
-                                            )
+                            if (imageUrl == null) {
+                                logger.error { "Fetching image for $nodeId failed due to null image URL" }
+                                instructionsForNode.forEach { _ ->
+                                    report.record(
+                                        ImportResult.Failure.NoImageUrl(
+                                            figmaFile = handler.figmaFile,
+                                            nodeId = nodeId,
                                         )
-                                    }
-                                    return@mapNotNull null
+                                    )
                                 }
+                                return@mapNotNull null
+                            }
 
-                                try {
+                            try {
                                     val imageResponse = downloaderHttpClient.get(
                                         urlString = imageUrl,
                                     )
                                     val bodyBytes = imageResponse.bodyAsChannel().toByteArray()
 
-                                    instructionsForNode.map { instruction ->
-                                        ExportOutput(
-                                            handler = handler,
-                                            instruction = instruction,
-                                            data = bodyBytes,
-                                            imageUrl = imageUrl,
-                                        )
-                                    }
-                                } catch (e: Throwable) {
-                                    logger.error(e) { "Failed fetching image for $nodeId at $imageUrl" }
+                                instructionsForNode.map { instruction ->
+                                    ExportOutput(
+                                        handler = handler,
+                                        instruction = instruction,
+                                        data = bodyBytes,
+                                        imageUrl = imageUrl,
+                                    )
+                                }
+                            } catch (e: Throwable) {
+                                logger.error(e) { "Failed fetching image for $nodeId at $imageUrl" }
                                     instructionsForNode.forEach { instruction ->
                                         report.record(
                                             ImportResult.Failure.DownloadFailed(
@@ -342,14 +289,13 @@ class FigmaAssetImporter(
                                             )
                                         )
                                     }
-                                    null
-                                }
+                                null
                             }
-                            .flatMapConcat { it.asFlow() }
-                            .flowOn(networkContext)
-                    }
-                    .flattenConcat()
-                    .flowOn(defaultContext)
+                        }
+                        .flatMapConcat { it.asFlow() }
+                        .collect { emit(it) }
+                }
+                    .flowOn(networkContext)
             }
 
         return exportFlow
@@ -394,13 +340,6 @@ class FigmaAssetImporter(
         val exportConfig: ExportConfig,
         val chunkIndex: Int,
         val instructions: List<Instruction>,
-        val isRetry: Boolean = false,
-    )
-
-    private data class GetImagesResult(
-        val originalChunk: Chunk,
-        val expectedInstructions: List<Instruction>,
-        val getImageResponse: ApiResponse<GetImageResponse>,
     )
 
     private data class ExportOutput(

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
@@ -242,8 +242,19 @@ class FigmaAssetImporter(
                     getImagesApiResponse.logError { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, $exportConfig" }
                     logger.info { "Getting images ${handler.figmaFile}, chunkIndex: $chunkIndex, $exportConfig: Finish ${getImagesApiResponse.isSuccess()}" }
 
-                    // TODO: error handling
-                    if (!getImagesApiResponse.isSuccess()) return@flow
+                    if (!getImagesApiResponse.isSuccess()) {
+                        val cause = (getImagesApiResponse as ApiResponse.Failure).asException()
+                        instructions.forEach { instruction ->
+                            report.record(
+                                ImportResult.Failure.GetImagesFailed(
+                                    figmaFile = handler.figmaFile,
+                                    nodeId = instruction.export.nodeId,
+                                    cause = cause,
+                                )
+                            )
+                        }
+                        return@flow
+                    }
 
                     val body = getImagesApiResponse.successBodyOrThrow()
                     body.images.entries.asFlow()

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/FigmaAssetImporter.kt
@@ -62,13 +62,19 @@ class FigmaAssetImporter(
             importFlow.launchIn(this)
         }
 
+        val failedFiles = mutableListOf<String>()
         for (report in reports.values) {
             importReportRepository.save(report)
             logger.info { report.summary() }
 
             if (report.hasFailures()) {
+                failedFiles += report.figmaFile
                 logger.error { "Import failures for ${report.figmaFile}: ${report.failures().size} failure(s)" }
             }
+        }
+
+        if (failedFiles.isNotEmpty()) {
+            throw ImportFailureException(failedFiles)
         }
     }
 

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/ImportFailureException.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/ImportFailureException.kt
@@ -1,0 +1,9 @@
+package com.anifichadia.figstract.importer.asset
+
+class ImportFailureException(val failedFiles: List<String>) : Exception(
+    buildString {
+        appendLine("Import completed with failures in ${failedFiles.size} file(s):")
+        failedFiles.forEach { appendLine("  - $it") }
+        append("Check the import report for details.")
+    }
+)

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
@@ -1,0 +1,51 @@
+package com.anifichadia.figstract.importer.asset.model
+
+import com.anifichadia.figstract.figma.FileKey
+import com.anifichadia.figstract.figma.NodeId
+
+/**
+ * Represents the outcome of a single image import operation within the pipeline.
+ * Collected per Figma file and written to a report at the end of each handler's flow.
+ */
+sealed interface ImportResult {
+    val figmaFile: FileKey
+    val nodeId: NodeId
+
+    data class Success(
+        override val figmaFile: FileKey,
+        override val nodeId: NodeId,
+        val imageUrl: String,
+        val instruction: Instruction,
+    ) : ImportResult
+
+    sealed interface Failure : ImportResult {
+        val reason: String
+        val cause: Throwable?
+
+        data class NoImageUrl(
+            override val figmaFile: FileKey,
+            override val nodeId: NodeId,
+        ) : Failure {
+            override val reason: String = "No image URL"
+            override val cause: Throwable? = null
+        }
+
+        data class DownloadFailed(
+            override val figmaFile: FileKey,
+            override val nodeId: NodeId,
+            val imageUrl: String,
+            override val cause: Throwable,
+        ) : Failure {
+            override val reason: String = "Failed to download image: ${cause.message}"
+        }
+
+        data class ImportPipelineFailed(
+            override val figmaFile: FileKey,
+            override val nodeId: NodeId,
+            val instruction: Instruction,
+            override val cause: Throwable,
+        ) : Failure {
+            override val reason: String = "Import pipeline failed: ${cause.message}"
+        }
+    }
+}

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
@@ -22,6 +22,14 @@ sealed interface ImportResult {
         val reason: String
         val cause: Throwable?
 
+        data class GetImagesFailed(
+            override val figmaFile: FileKey,
+            override val nodeId: NodeId,
+            override val cause: Throwable,
+        ) : Failure {
+            override val reason: String = "Failed to retrieve image URL: ${cause.message}"
+        }
+
         data class NoImageUrl(
             override val figmaFile: FileKey,
             override val nodeId: NodeId,

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/model/ImportResult.kt
@@ -9,11 +9,10 @@ import com.anifichadia.figstract.figma.NodeId
  */
 sealed interface ImportResult {
     val figmaFile: FileKey
-    val nodeId: NodeId
 
     data class Success(
         override val figmaFile: FileKey,
-        override val nodeId: NodeId,
+        val nodeId: NodeId,
         val imageUrl: String,
         val instruction: Instruction,
     ) : ImportResult
@@ -22,38 +21,49 @@ sealed interface ImportResult {
         val reason: String
         val cause: Throwable?
 
-        data class GetImagesFailed(
+        data class GetFileFailed(
             override val figmaFile: FileKey,
-            override val nodeId: NodeId,
             override val cause: Throwable,
         ) : Failure {
-            override val reason: String = "Failed to retrieve image URL: ${cause.message}"
+            override val reason: String = "Failed to retrieve file: ${cause.message}"
         }
 
-        data class NoImageUrl(
-            override val figmaFile: FileKey,
-            override val nodeId: NodeId,
-        ) : Failure {
-            override val reason: String = "No image URL"
-            override val cause: Throwable? = null
-        }
+        sealed interface NodeFailure : Failure {
+            val nodeId: NodeId
 
-        data class DownloadFailed(
-            override val figmaFile: FileKey,
-            override val nodeId: NodeId,
-            val imageUrl: String,
-            override val cause: Throwable,
-        ) : Failure {
-            override val reason: String = "Failed to download image: ${cause.message}"
-        }
+            data class GetImagesFailed(
+                override val figmaFile: FileKey,
+                override val nodeId: NodeId,
+                override val cause: Throwable,
+            ) : NodeFailure {
+                override val reason: String = "Failed to retrieve image URL: ${cause.message}"
+            }
 
-        data class ImportPipelineFailed(
-            override val figmaFile: FileKey,
-            override val nodeId: NodeId,
-            val instruction: Instruction,
-            override val cause: Throwable,
-        ) : Failure {
-            override val reason: String = "Import pipeline failed: ${cause.message}"
+            data class NoImageUrl(
+                override val figmaFile: FileKey,
+                override val nodeId: NodeId,
+            ) : NodeFailure {
+                override val reason: String = "No image URL"
+                override val cause: Throwable? = null
+            }
+
+            data class DownloadFailed(
+                override val figmaFile: FileKey,
+                override val nodeId: NodeId,
+                val imageUrl: String,
+                override val cause: Throwable,
+            ) : NodeFailure {
+                override val reason: String = "Failed to download image: ${cause.message}"
+            }
+
+            data class ImportPipelineFailed(
+                override val figmaFile: FileKey,
+                override val nodeId: NodeId,
+                val instruction: Instruction,
+                override val cause: Throwable,
+            ) : NodeFailure {
+                override val reason: String = "Import pipeline failed: ${cause.message}"
+            }
         }
     }
 }

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/FigmaImportReport.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/FigmaImportReport.kt
@@ -1,0 +1,35 @@
+package com.anifichadia.figstract.importer.asset.reporting
+
+import com.anifichadia.figstract.importer.asset.model.ImportResult
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Thread-safe accumulator for [ImportResult]s associated with a single Figma file.
+ */
+class FigmaImportReport(val figmaFile: String) {
+    private val results = ConcurrentLinkedQueue<ImportResult>()
+
+    fun record(result: ImportResult) {
+        results.add(result)
+    }
+
+    fun results(): List<ImportResult> = results.toList()
+
+    fun successes(): List<ImportResult.Success> =
+        results.filterIsInstance<ImportResult.Success>()
+
+    fun failures(): List<ImportResult.Failure> =
+        results.filterIsInstance<ImportResult.Failure>()
+
+    fun hasFailures(): Boolean = results.any { it is ImportResult.Failure }
+
+    fun summary(): String = buildString {
+        val allResults = results()
+        val successes = allResults.filterIsInstance<ImportResult.Success>()
+        val failures = allResults.filterIsInstance<ImportResult.Failure>()
+        appendLine("=== Import Report: $figmaFile ===")
+        appendLine("Total:    ${allResults.size}")
+        appendLine("Success:  ${successes.size}")
+        appendLine("Failures: ${failures.size}")
+    }
+}

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/FigmaImportReport.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/FigmaImportReport.kt
@@ -6,10 +6,15 @@ import java.util.concurrent.ConcurrentLinkedQueue
 /**
  * Thread-safe accumulator for [ImportResult]s associated with a single Figma file.
  */
-class FigmaImportReport(val figmaFile: String) {
+class FigmaImportReport(
+    val figmaFile: String,
+    private val ignoreNoImageUrlFailures: Boolean = true,
+) {
     private val results = ConcurrentLinkedQueue<ImportResult>()
 
     fun record(result: ImportResult) {
+        if (ignoreNoImageUrlFailures && result is ImportResult.Failure.NodeFailure.NoImageUrl) return
+
         results.add(result)
     }
 

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
@@ -29,14 +29,20 @@ data class ImportReportDocument(
 
     @Serializable
     sealed class FailureEntry {
-        abstract val nodeId: String
         abstract val reason: String
         abstract val cause: String?
 
         @Serializable
+        @SerialName("get_file_failed")
+        data class GetFileFailed(
+            override val reason: String,
+            override val cause: String?,
+        ) : FailureEntry()
+
+        @Serializable
         @SerialName("get_images_failed")
         data class GetImagesFailed(
-            override val nodeId: String,
+            val nodeId: String,
             override val reason: String,
             override val cause: String?,
         ) : FailureEntry()
@@ -44,7 +50,7 @@ data class ImportReportDocument(
         @Serializable
         @SerialName("no_image_url")
         data class NoImageUrl(
-            override val nodeId: String,
+            val nodeId: String,
             override val reason: String,
             override val cause: String? = null,
         ) : FailureEntry()
@@ -52,7 +58,7 @@ data class ImportReportDocument(
         @Serializable
         @SerialName("download_failed")
         data class DownloadFailed(
-            override val nodeId: String,
+            val nodeId: String,
             override val reason: String,
             override val cause: String?,
             val imageUrl: String,
@@ -61,7 +67,7 @@ data class ImportReportDocument(
         @Serializable
         @SerialName("import_pipeline_failed")
         data class ImportPipelineFailed(
-            override val nodeId: String,
+            val nodeId: String,
             override val reason: String,
             override val cause: String?,
             val instruction: String,
@@ -91,28 +97,39 @@ data class ImportReportDocument(
                         )
                     },
                 failures = failures
-                    .sortedBy { it.nodeId }
+                    .sortedWith(
+                        compareBy(
+                            // File-level failures first, then node-level sorted by nodeId
+                            { it !is ImportResult.Failure.GetFileFailed },
+                            { (it as? ImportResult.Failure.NodeFailure)?.nodeId ?: "" },
+                        )
+                    )
                     .map { f ->
                         when (f) {
-                            is ImportResult.Failure.GetImagesFailed -> FailureEntry.GetImagesFailed(
+                            is ImportResult.Failure.GetFileFailed -> FailureEntry.GetFileFailed(
+                                reason = f.reason,
+                                cause = f.cause.message,
+                            )
+
+                            is ImportResult.Failure.NodeFailure.GetImagesFailed -> FailureEntry.GetImagesFailed(
                                 nodeId = f.nodeId,
                                 reason = f.reason,
                                 cause = f.cause.message,
                             )
 
-                            is ImportResult.Failure.NoImageUrl -> FailureEntry.NoImageUrl(
+                            is ImportResult.Failure.NodeFailure.NoImageUrl -> FailureEntry.NoImageUrl(
                                 nodeId = f.nodeId,
                                 reason = f.reason,
                             )
 
-                            is ImportResult.Failure.DownloadFailed -> FailureEntry.DownloadFailed(
+                            is ImportResult.Failure.NodeFailure.DownloadFailed -> FailureEntry.DownloadFailed(
                                 nodeId = f.nodeId,
                                 reason = f.reason,
                                 cause = f.cause.message,
                                 imageUrl = f.imageUrl,
                             )
 
-                            is ImportResult.Failure.ImportPipelineFailed -> FailureEntry.ImportPipelineFailed(
+                            is ImportResult.Failure.NodeFailure.ImportPipelineFailed -> FailureEntry.ImportPipelineFailed(
                                 nodeId = f.nodeId,
                                 reason = f.reason,
                                 cause = f.cause.message,

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
@@ -1,0 +1,112 @@
+package com.anifichadia.figstract.importer.asset.reporting
+
+import com.anifichadia.figstract.importer.asset.model.ImportResult
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+@Serializable
+data class ImportReportDocument(
+    val figmaFile: String,
+    val generatedAt: Instant,
+    val summary: Summary,
+    val failures: List<FailureEntry>,
+    val successes: List<SuccessEntry>,
+) {
+    @Serializable
+    data class Summary(
+        val total: Int,
+        val successes: Int,
+        val failures: Int,
+    )
+
+    @Serializable
+    data class SuccessEntry(
+        val nodeId: String,
+        val imageUrl: String,
+        val instruction: String,
+    )
+
+    @Serializable
+    sealed class FailureEntry {
+        abstract val nodeId: String
+        abstract val reason: String
+        abstract val cause: String?
+
+        @Serializable
+        @SerialName("no_image_url")
+        data class NoImageUrl(
+            override val nodeId: String,
+            override val reason: String,
+            override val cause: String? = null,
+        ) : FailureEntry()
+
+        @Serializable
+        @SerialName("download_failed")
+        data class DownloadFailed(
+            override val nodeId: String,
+            override val reason: String,
+            override val cause: String?,
+            val imageUrl: String,
+        ) : FailureEntry()
+
+        @Serializable
+        @SerialName("import_pipeline_failed")
+        data class ImportPipelineFailed(
+            override val nodeId: String,
+            override val reason: String,
+            override val cause: String?,
+            val instruction: String,
+        ) : FailureEntry()
+    }
+
+    companion object {
+        fun from(report: FigmaImportReport, generatedAt: Instant): ImportReportDocument {
+            val successes = report.successes()
+            val failures = report.failures()
+
+            return ImportReportDocument(
+                figmaFile = report.figmaFile,
+                generatedAt = generatedAt,
+                summary = Summary(
+                    total = successes.size + failures.size,
+                    successes = successes.size,
+                    failures = failures.size,
+                ),
+                successes = successes
+                    .sortedBy { it.nodeId }
+                    .map { s ->
+                        SuccessEntry(
+                            nodeId = s.nodeId,
+                            imageUrl = s.imageUrl,
+                            instruction = s.instruction.toString(),
+                        )
+                    },
+                failures = failures
+                    .sortedBy { it.nodeId }
+                    .map { f ->
+                        when (f) {
+                            is ImportResult.Failure.NoImageUrl -> FailureEntry.NoImageUrl(
+                                nodeId = f.nodeId,
+                                reason = f.reason,
+                            )
+
+                            is ImportResult.Failure.DownloadFailed -> FailureEntry.DownloadFailed(
+                                nodeId = f.nodeId,
+                                reason = f.reason,
+                                cause = f.cause.message,
+                                imageUrl = f.imageUrl,
+                            )
+
+                            is ImportResult.Failure.ImportPipelineFailed -> FailureEntry.ImportPipelineFailed(
+                                nodeId = f.nodeId,
+                                reason = f.reason,
+                                cause = f.cause.message,
+                                instruction = f.instruction.toString(),
+                            )
+                        }
+                    },
+            )
+        }
+    }
+}

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportDocument.kt
@@ -34,6 +34,14 @@ data class ImportReportDocument(
         abstract val cause: String?
 
         @Serializable
+        @SerialName("get_images_failed")
+        data class GetImagesFailed(
+            override val nodeId: String,
+            override val reason: String,
+            override val cause: String?,
+        ) : FailureEntry()
+
+        @Serializable
         @SerialName("no_image_url")
         data class NoImageUrl(
             override val nodeId: String,
@@ -86,6 +94,12 @@ data class ImportReportDocument(
                     .sortedBy { it.nodeId }
                     .map { f ->
                         when (f) {
+                            is ImportResult.Failure.GetImagesFailed -> FailureEntry.GetImagesFailed(
+                                nodeId = f.nodeId,
+                                reason = f.reason,
+                                cause = f.cause.message,
+                            )
+
                             is ImportResult.Failure.NoImageUrl -> FailureEntry.NoImageUrl(
                                 nodeId = f.nodeId,
                                 reason = f.reason,

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportRepository.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/ImportReportRepository.kt
@@ -1,0 +1,5 @@
+package com.anifichadia.figstract.importer.asset.reporting
+
+interface ImportReportRepository {
+    suspend fun save(report: FigmaImportReport)
+}

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/JsonImportReportRepository.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/JsonImportReportRepository.kt
@@ -1,0 +1,40 @@
+package com.anifichadia.figstract.importer.asset.reporting
+
+import com.anifichadia.figstract.util.createLogger
+import kotlinx.serialization.json.Json
+import java.io.File
+import kotlin.time.Clock
+
+class JsonFileImportReportRepository(
+    private val outputDir: File,
+    private val json: Json = DefaultJson,
+) : ImportReportRepository {
+
+    init {
+        outputDir.mkdirs()
+    }
+
+    override suspend fun save(report: FigmaImportReport) {
+        val generatedAt = Clock.System.now()
+        val timestamp = generatedAt.toString().replace(':', '-')
+
+        val reportFile = outputDir.resolve("import_report_${report.figmaFile}_$timestamp.json")
+
+        val document = ImportReportDocument.from(
+            report = report,
+            generatedAt = generatedAt,
+        )
+        reportFile.writeText(json.encodeToString(document))
+
+        logger.info { "Report written to: ${reportFile.absolutePath}" }
+    }
+
+    companion object {
+        private val logger = createLogger("JsonFileImportReportRepository")
+
+        val DefaultJson = Json {
+            prettyPrint = true
+            encodeDefaults = true
+        }
+    }
+}

--- a/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/NoOpImportReportRepository.kt
+++ b/library-core/src/main/java/com/anifichadia/figstract/importer/asset/reporting/NoOpImportReportRepository.kt
@@ -1,0 +1,5 @@
+package com.anifichadia.figstract.importer.asset.reporting
+
+class NoOpImportReportRepository : ImportReportRepository {
+    override suspend fun save(report: FigmaImportReport) = Unit
+}


### PR DESCRIPTION
Tracks failures when importing assets
Fails the program if importing fails at any point

General error handling ... implementations
Relocates `FigmaApi,getImages` failure handling to `FigmaApiProxyWithFlowControl`
