### PR TITLE
Updates iOS icon export config to use absolute bounds

### DIFF
--- a/library-ios/src/main/java/com/anifichadia/figstract/ios/figma/model/ExportConfigs.kt
+++ b/library-ios/src/main/java/com/anifichadia/figstract/ios/figma/model/ExportConfigs.kt
@@ -7,6 +7,7 @@ import com.anifichadia.figstract.ios.assetcatalog.Scale
 
 val iosIcon = ExportConfig(
     format = ExportSetting.Format.PDF,
+    useAbsoluteBounds = true,
 )
 
 /** This is a template and should not be used directly. The [ExportConfig.scale] has been set to an impossible value. */


### PR DESCRIPTION
To prevent awkward cropping